### PR TITLE
Add support for Fresh Start Worlds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Heur
 
 ```
 
+#### Targets
+Table of all available OSRS Highscore boards and the associated ```target``` value used when instantiating a
+```Highscores``` object to query them.
+
+| Target               | Value                  |
+|----------------------|------------------------|
+| OSRS Highscores      | ```default```          |
+| Ironman              | ```ironman```          |
+| Ultimate Ironman     | ```ultimate```         |
+| Hardcore Ironman     | ```hardcore_ironman``` |
+| Seasonal             | ```seasonal```         |
+| Deadman Mode         | ```deadman```          |
+| Tournament           | ```tournament```       |
+| Fresh Start Worlds   | ```fresh_start```      |
+
 
 #### Highscores Attributes
 Table of all available attributes for highscores object

--- a/osrs_highscores/base.py
+++ b/osrs_highscores/base.py
@@ -69,5 +69,7 @@ class OSRSBase(object):
             return self.__format_url("hiscore_oldschool_deadman", **kwargs)
         elif self.target == 'tournament':
             return self.__format_url("hiscore_oldschool_tournament", **kwargs)
+        elif self.target == 'fresh_start':
+            return self.__format_url("hiscore_oldschool_fresh_start", **kwargs)
         else:
             raise ValueError('Invalid target param for Highscores Instance.')


### PR DESCRIPTION
Adds support for the Highscores for the new Fresh Start Worlds and updates README to include a value reference table for the ```Highscores``` object's ```target``` keyword argument.