### PR TITLE
Update spelling of Calvar'ion attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ All Clues Rank: 433023
 | barrows_chests                   |41|17|
 | bryophyta                        |42|18|
 | callisto                         |43|19|
-| cal_varion                       |44|20|
+| calvar_ion                       |44|20|
 | cerberus                         |45|21|
 | chambers_of_xeric                |46|22|
 | chambers_of_xeric_challenge_mode |47|23|

--- a/osrs_highscores/resources/categories.py
+++ b/osrs_highscores/resources/categories.py
@@ -49,7 +49,7 @@ default_boss_ranks = [
     "barrows_chests",
     "bryophyta",
     "callisto",
-    "cal_varion",
+    "calvar_ion",
     "cerberus",
     "chambers_of_xeric",
     "chambers_of_xeric_challenge_mode",


### PR DESCRIPTION
 Updates the spelling of the Calvar'ion attribute from `cal_varion` to `calvar_ion` now that Jagex consistently uses the latter spelling everywhere.